### PR TITLE
Fixed Property error - ClassName

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "expo/tsconfig.base",
+  "extends": ["expo/tsconfig.base"],
    "compilerOptions": {
         "jsx": "react",
         "strict": true,
@@ -9,6 +9,7 @@
         "esModuleInterop": true,
         "skipLibCheck": true,
         "resolveJsonModule": true,
-        "lib": ["esnext", "dom"]
+        "lib": ["esnext", "dom"],
+        "types": ["nativewind/types"]
     }
 }


### PR DESCRIPTION
TailWind property className wasn't being recognized as a valid prop for React Native components.
To fix this, I added NativeWind type definitions to extend React Native's default typings. 
Also added "extends" values in an array to remove the error I was getting. 